### PR TITLE
Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,12 @@ matrix:
       osx_image: xcode9.2
       env: BUILDTYPE=release
       node_js: 8
-    #
-    # - os: linux
-    #   env: BUILDTYPE=release
-    #   node_js: 10
-    #
-    # - os: osx
-    #   osx_image: xcode9.2
-    #   env: BUILDTYPE=release
-    #   node_js: 10
+
+    - os: linux
+      env: BUILDTYPE=release
+      node_js: 10
+
+    - os: osx
+      osx_image: xcode9.2
+      env: BUILDTYPE=release
+      node_js: 10

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -143,23 +143,23 @@ dependencies = [
 
 [[package]]
 name = "neon"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cslice 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "neon-build 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "neon-runtime 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "neon-build 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "neon-runtime 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "neon-build"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "neon-runtime"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cslice 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -174,7 +174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "neon 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "neon 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -183,8 +183,8 @@ name = "node-fuzzy-phrase"
 version = "0.1.0"
 dependencies = [
  "fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=279900c73750ff1f3620f82ffb3e8588b1d16f79)",
- "neon 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "neon-build 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "neon 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "neon-build 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-serde 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -408,9 +408,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
-"checksum neon 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "6f6078a0767408131206f802cb4ee2b1d78a035f23c209c3c0cb1dbe258a8737"
-"checksum neon-build 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "0220c1150ca0ac00df8fc1001dde699cf17762f208f43c497d90e91c910c0a17"
-"checksum neon-runtime 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "9a53b08f4dfc0ebc9ecb8bd8a02ace763e833d657f03614293254420a413c036"
+"checksum neon 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "4eb8561df7e868280675716d25b8d188c159cdefdb929bca63146b719db835a3"
+"checksum neon-build 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "253eda9b9a20b313e69e9b6a1c3457bd0bcb13e093a5b677ef7f986dd7494bb3"
+"checksum neon-runtime 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "cbfeca12e0507cfb8e9aaa5a0b4dd95baf93b0b1125457a58fc624e2537a3ea5"
 "checksum neon-serde 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "03eb25ea2c60da2b6331b9c4b0eb55ab565b1552721b99674a382514a754af45"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -10,10 +10,10 @@ name = "node_fuzzy_phrase"
 crate-type = ["dylib"]
 
 [build-dependencies]
-neon-build = "0.1.22"
+neon-build = "0.1.23"
 
 [dependencies]
-neon = "0.1.22"
+neon = "0.1.23"
 serde = "1.x"
 serde_derive = "1.x"
 neon-serde = "0.0.3"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,4 +17,4 @@ neon = "0.1.23"
 serde = "1.x"
 serde_derive = "1.x"
 neon-serde = "0.0.3"
-fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "279900c73750ff1f3620f82ffb3e8588b1d16f79" }
+fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "ff44810c167951713d4c6c87264a28e94a533965" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-fuzzy-phrase",
-  "version": "0.1.0-dev3",
+  "version": "0.1.0-dev5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -402,17 +402,17 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.1"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
     },
     "colors": {
       "version": "1.3.0",
@@ -1204,9 +1204,9 @@
       }
     },
     "neon-cli": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/neon-cli/-/neon-cli-0.1.22.tgz",
-      "integrity": "sha512-347dLid0g82Jc/wD0crX2sRXBdcu7fnZdlUVCE96xrjoJBqhgKxCB/3+W+jYPtI1x5nl9vWIqcHbiD8PhlwdVw==",
+      "version": "0.1.23",
+      "resolved": "https://registry.npmjs.org/neon-cli/-/neon-cli-0.1.23.tgz",
+      "integrity": "sha512-C5Rw82cDsQFuvFBlql3cuMm0UGRFdBOvcjSA6Di59EFnrqEnajeqF2Z1X6/tJK3VdhrNyWieYr8L27Qfxj3Gvg==",
       "requires": {
         "chalk": "~2.1.0",
         "command-line-args": "^4.0.2",
@@ -1578,9 +1578,9 @@
       }
     },
     "rsvp": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.2.tgz",
-      "integrity": "sha512-8CU1Wjxvzt6bt8zln+hCjyieneU9s0LRW+lPRsjyVCY8Vm1kTbK7btBIrCGg6yY9U4undLDm/b1hKEEi1tLypg=="
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.3.tgz",
+      "integrity": "sha512-/OlbK31XtkPnLD2ktmZXj4g/v6q1boTDr6/3lFuDTgxVsrA3h7PH5eYyAxIvDMjRHr/DoOlzNicqDwBEo9xU7g=="
     },
     "run-async": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-fuzzy-phrase",
-  "version": "0.1.0-dev5",
+  "version": "0.1.0-n10",
   "description": "neon module for wrapping fuzzy-phrase",
   "main": "lib/index.js",
   "author": "Andrea del Rio <adelrio@gmail.com>",
@@ -8,7 +8,7 @@
   "dependencies": {
     "@mapbox/cfn-config": "^2.15.0",
     "@mapbox/cloudfriend": "^1.9.1",
-    "neon-cli": "^0.1.22",
+    "neon-cli": "^0.1.23",
     "node-pre-gyp": "~0.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It turns out neon had a release before 0.2 that added node 10 support. This upgrades our dep (which had some other improvements), and enables node 10 binaries and tests, because why not.

We should still circle back and do Node 0.2 at some point, but are waiting, among other things, on neon_serde.