### PR TITLE
[dnm] Build node-fuzzy-phrase against fuzzy-phrase@no-mmap

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -82,13 +82,12 @@ dependencies = [
 [[package]]
 name = "fuzzy-phrase"
 version = "0.1.0"
-source = "git+https://github.com/mapbox/fuzzy-phrase?rev=0b03cbf1aede9d0a43aa28dffa828e2c62f1484e#0b03cbf1aede9d0a43aa28dffa828e2c62f1484e"
+source = "git+https://github.com/mapbox/fuzzy-phrase?rev=1cb4ebadd6b384ee8b5b970b31a743e8aaedc394#1cb4ebadd6b384ee8b5b970b31a743e8aaedc394"
 dependencies = [
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fst 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -182,7 +181,7 @@ dependencies = [
 name = "node-fuzzy-phrase"
 version = "0.1.0"
 dependencies = [
- "fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=0b03cbf1aede9d0a43aa28dffa828e2c62f1484e)",
+ "fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=1cb4ebadd6b384ee8b5b970b31a743e8aaedc394)",
  "neon 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-serde 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -400,7 +399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum fst 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d94485a00b1827b861dd9d1a2cc9764f9044d4c535514c0760a5a2012ef3399f"
-"checksum fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=0b03cbf1aede9d0a43aa28dffa828e2c62f1484e)" = "<none>"
+"checksum fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=1cb4ebadd6b384ee8b5b970b31a743e8aaedc394)" = "<none>"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,4 +17,4 @@ neon = "0.1.23"
 serde = "1.x"
 serde_derive = "1.x"
 neon-serde = "0.0.3"
-fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "0b03cbf1aede9d0a43aa28dffa828e2c62f1484e" }
+fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "1cb4ebadd6b384ee8b5b970b31a743e8aaedc394" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-fuzzy-phrase",
-  "version": "0.1.3",
+  "version": "0.1.3-no-mmap",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/node-fuzzy-phrase",
-  "version": "0.1.3",
+  "version": "0.1.3-no-mmap",
   "description": "neon module for wrapping fuzzy-phrase",
   "main": "lib/index.js",
   "author": "Andrea del Rio <adelrio@gmail.com>",


### PR DESCRIPTION
This points node-fuzzy-phrase at https://github.com/mapbox/fuzzy-phrase/pull/51 . Note that the circle fail is a lie; it's because our travis setup does weird things with `[publish binary]` commits. A dummy commit would fix it should we want to merge.