### PR TITLE
Adds load_token_replacement functionality in fuzzy-phrase to javascript

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,4 +17,4 @@ neon = "0.1.23"
 serde = "1.x"
 serde_derive = "1.x"
 neon-serde = "0.0.3"
-fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "9da10eebec306b4dde8903b9d74ef9656f1c2f79" }
+fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "c18ffaec48b285d441eb9f332d4681eb665ebb22" }

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,4 +17,4 @@ neon = "0.1.23"
 serde = "1.x"
 serde_derive = "1.x"
 neon-serde = "0.0.3"
-fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "c18ffaec48b285d441eb9f332d4681eb665ebb22" }
+fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "9da10eebec306b4dde8903b9d74ef9656f1c2f79" }

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,4 +17,4 @@ neon = "0.1.23"
 serde = "1.x"
 serde_derive = "1.x"
 neon-serde = "0.0.3"
-fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "c18ffaec48b285d441eb9f332d4681eb665ebb22" }
+fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "eb9a4822f4ed8d9a57311bf834199ff0be129777" }

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,4 +17,4 @@ neon = "0.1.23"
 serde = "1.x"
 serde_derive = "1.x"
 neon-serde = "0.0.3"
-fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "0b03cbf1aede9d0a43aa28dffa828e2c62f1484e" }
+fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "c18ffaec48b285d441eb9f332d4681eb665ebb22" }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -9,7 +9,7 @@ use neon::js::{JsFunction, Object, JsString, JsNumber, Value, JsUndefined, JsArr
 use neon::js::class::{JsClass, Class};
 use neon::js::error::{Kind, JsError};
 
-use fuzzy_phrase::glue::{FuzzyPhraseSetBuilder, FuzzyPhraseSet};
+use fuzzy_phrase::glue::{FuzzyPhraseSetBuilder, FuzzyPhraseSet, WordReplacement};
 
 trait CheckArgument {
     fn check_argument<V: Value>(&mut self, i: i32) -> JsResult<V>;
@@ -68,6 +68,24 @@ declare_types! {
                     },
                     None => {
                         JsError::throw(Kind::TypeError, "unable to insert()")
+                    }
+                }
+            })
+        }
+
+        method loadWordReplacements(call) {
+            let scope = call.scope;
+            let mut this: Handle<JsFuzzyPhraseSetBuilder> = call.arguments.this(call.scope);
+            let mut v: Vec<WordReplacement> = Vec::new();
+
+            this.grab(|fuzzyphrasesetbuilder| {
+                match fuzzyphrasesetbuilder {
+                    Some(builder) => {
+                        match builder.load_word_replacements(v) {
+                        }
+                    },
+                    None => {
+                        JsError::throw(Kind::TypeError, "unable to load_word_replacements()")
                     }
                 }
             })

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -75,13 +75,21 @@ declare_types! {
 
         method loadWordReplacements(call) {
             let scope = call.scope;
-            let mut this: Handle<JsFuzzyPhraseSetBuilder> = call.arguments.this(call.scope);
-            let mut v: Vec<WordReplacement> = Vec::new();
+            let mut this: Handle<JsFuzzyPhraseSetBuilder> = call.arguments.this(scope);
+            let word_array = call.arguments.require(scope, 0)?;
+            let word_replacements: Vec<WordReplacement> = neon_serde::from_value(scope, word_array)?;
 
             this.grab(|fuzzyphrasesetbuilder| {
                 match fuzzyphrasesetbuilder {
                     Some(builder) => {
-                        match builder.load_word_replacements(v) {
+                        match builder.load_word_replacements(word_replacements) {
+                            Ok(_) => {
+                                Ok(JsUndefined::new().upcast())
+                            },
+                            Err(e) => {
+                                println!("{:?}", e);
+                                JsError::throw(Kind::TypeError, e.description())
+                            }
                         }
                     },
                     None => {

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -82,15 +82,8 @@ declare_types! {
             this.grab(|fuzzyphrasesetbuilder| {
                 match fuzzyphrasesetbuilder {
                     Some(builder) => {
-                        match builder.load_word_replacements(word_replacements) {
-                            Ok(_) => {
-                                Ok(JsUndefined::new().upcast())
-                            },
-                            Err(e) => {
-                                println!("{:?}", e);
-                                JsError::throw(Kind::TypeError, e.description())
-                            }
-                        }
+                        builder.load_word_replacements(word_replacements);
+                        Ok(JsUndefined::new().upcast())
                     },
                     None => {
                         JsError::throw(Kind::TypeError, "unable to load_word_replacements()")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/node-fuzzy-phrase",
-  "version": "0.1.3-tokens",
+  "version": "0.1.3-tokens-1",
   "description": "neon module for wrapping fuzzy-phrase",
   "main": "lib/index.js",
   "author": "Andrea del Rio <adelrio@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/node-fuzzy-phrase",
-  "version": "0.1.3",
+  "version": "0.1.3-tokens",
   "description": "neon module for wrapping fuzzy-phrase",
   "main": "lib/index.js",
   "author": "Andrea del Rio <adelrio@gmail.com>",

--- a/test/all.js
+++ b/test/all.js
@@ -206,10 +206,10 @@ tape('FuzzyPhraseSetBuilder insertion and Set lookup', (t) => {
 });
 
 tape('load word replacements', (t) => {
-    let builder = new fuzzy.FuzzyPhraseSetBuilder(tmpDir.name);
+    const builder = new fuzzy.FuzzyPhraseSetBuilder(tmpDir.name);
     builder.loadWordReplacements([{ from: 'Street', to: 'Str' }]);
     builder.finish();
-    var word_replacements_obj = JSON.parse(fs.readFileSync(tmpDir.name + '/metadata.json')).word_replacements;
-    t.deepEquals(word_replacements_obj, [ { from: 'Street', to: 'Str' } ], 'ok, loads word replacements')
+    const word_replacements_obj = JSON.parse(fs.readFileSync(tmpDir.name + '/metadata.json')).word_replacements;
+    t.deepEquals(word_replacements_obj, [{ from: 'Street', to: 'Str' }], 'ok, loads word replacements');
     t.end();
 });

--- a/test/all.js
+++ b/test/all.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 const tape = require('tape');
 const tmp = require('tmp');
 const rimraf = require('rimraf').sync;
+const fs = require('fs');
 
 const tmpDir = tmp.dirSync();
 
@@ -129,5 +130,8 @@ tape("FuzzyPhraseSetBuilder insertion and Set lookup", (t) => {
 tape('load word replacements', (t) => {
     let builder = new fuzzy.FuzzyPhraseSetBuilder(tmpDir.name);
     builder.loadWordReplacements([{ from: 'Street', to: 'Str' }]);
+    builder.finish();
+    var word_replacements_obj = JSON.parse(fs.readFileSync(tmpDir.name + '/metadata.json')).word_replacements;
+    t.deepEquals(word_replacements_obj, [ { from: 'Street', to: 'Str' } ], 'ok, loads word replacements')
     t.end();
 })

--- a/test/all.js
+++ b/test/all.js
@@ -18,7 +18,6 @@ tape('build FuzzyPhraseSetBuilder', (t) => {
 
 tape("FuzzyPhraseSetBuilder insertion and Set lookup", (t) => {
     let builder = new fuzzy.FuzzyPhraseSetBuilder(tmpDir.name);
-
     builder.insert(["100","main","street"]);
     builder.insert(["200","main","street"]);
     builder.insert(["100","main","ave"]);
@@ -124,5 +123,11 @@ tape("FuzzyPhraseSetBuilder insertion and Set lookup", (t) => {
 
     rimraf(tmpDir.name);
 
+    t.end();
+})
+
+tape('load word replacements', (t) => {
+    let builder = new fuzzy.FuzzyPhraseSetBuilder(tmpDir.name);
+    builder.loadWordReplacements([{ from: 'Street', to: 'Str' }]);
     t.end();
 })


### PR DESCRIPTION
Per #15, 

Adds https://github.com/mapbox/fuzzy-phrase/issues/53 to javascript. Ended up returning `Result<(), Box<Error>>` in `load_token_replacement` here - https://github.com/mapbox/fuzzy-phrase/commit/9da10eebec306b4dde8903b9d74ef9656f1c2f79, because I kept running into - 

```
Ok(_f) => {                                                                                              
    |                             ^^^^^^ expected (), found enum `std::result::Result`
``

Tried a number of things: 
1. Explicitly setting the return type for `method loadWordReplacements` to Box<Error> which complied okay, but didn't seem like something we should have to do. 
2. After it compiled it said it threw and error `couldn't find builder.loadWordReplacements` while running tests 

cc @apendleton, @boblannon 
