### PR TITLE
Switch to fuzzy-phrase@word-boundaries

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,3 +3,8 @@
 const fuzzyPhrase = require('../native/index.node');
 
 module.exports = fuzzyPhrase;
+module.exports.ENDING_TYPE = {
+    nonPrefix: 0,
+    anyPrefix: 1,
+    wordBoundaryPrefix: 2,
+}

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 [[package]]
 name = "fuzzy-phrase"
 version = "0.1.0"
-source = "git+https://github.com/mapbox/fuzzy-phrase?rev=0b03cbf1aede9d0a43aa28dffa828e2c62f1484e#0b03cbf1aede9d0a43aa28dffa828e2c62f1484e"
+source = "git+https://github.com/mapbox/fuzzy-phrase?rev=218d3aac6dc1559a2d42581921455a6d29b37542#218d3aac6dc1559a2d42581921455a6d29b37542"
 dependencies = [
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fst 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -91,6 +91,7 @@ dependencies = [
  "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -182,7 +183,7 @@ dependencies = [
 name = "node-fuzzy-phrase"
 version = "0.1.0"
 dependencies = [
- "fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=0b03cbf1aede9d0a43aa28dffa828e2c62f1484e)",
+ "fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=218d3aac6dc1559a2d42581921455a6d29b37542)",
  "neon 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-serde 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -282,6 +283,14 @@ dependencies = [
 name = "rustc-demangle"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-hash"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "semver"
@@ -400,7 +409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum fst 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d94485a00b1827b861dd9d1a2cc9764f9044d4c535514c0760a5a2012ef3399f"
-"checksum fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=0b03cbf1aede9d0a43aa28dffa828e2c62f1484e)" = "<none>"
+"checksum fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=218d3aac6dc1559a2d42581921455a6d29b37542)" = "<none>"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
@@ -423,6 +432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d45d7afc9b132b34a2479648863aa95c5c88e98b32285326a6ebadc80ec5c9"
 "checksum rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
 "checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
+"checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)" = "fba5be06346c5200249c8c8ca4ccba4a09e8747c71c16e420bd359a0db4d8f91"

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 [[package]]
 name = "fuzzy-phrase"
 version = "0.1.0"
-source = "git+https://github.com/mapbox/fuzzy-phrase?rev=218d3aac6dc1559a2d42581921455a6d29b37542#218d3aac6dc1559a2d42581921455a6d29b37542"
+source = "git+https://github.com/mapbox/fuzzy-phrase?rev=3c85f2a9b5f49e4adf052799f09a5f6680efec7e#3c85f2a9b5f49e4adf052799f09a5f6680efec7e"
 dependencies = [
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fst 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -183,7 +183,7 @@ dependencies = [
 name = "node-fuzzy-phrase"
 version = "0.1.0"
 dependencies = [
- "fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=218d3aac6dc1559a2d42581921455a6d29b37542)",
+ "fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=3c85f2a9b5f49e4adf052799f09a5f6680efec7e)",
  "neon 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-serde 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -409,7 +409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum fst 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d94485a00b1827b861dd9d1a2cc9764f9044d4c535514c0760a5a2012ef3399f"
-"checksum fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=218d3aac6dc1559a2d42581921455a6d29b37542)" = "<none>"
+"checksum fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=3c85f2a9b5f49e4adf052799f09a5f6680efec7e)" = "<none>"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,4 +17,4 @@ neon = "0.1.23"
 serde = "1.x"
 serde_derive = "1.x"
 neon-serde = "0.0.3"
-fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "9da10eebec306b4dde8903b9d74ef9656f1c2f79" }
+fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "c18ffaec48b285d441eb9f332d4681eb665ebb22" }

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,4 +17,4 @@ neon = "0.1.23"
 serde = "1.x"
 serde_derive = "1.x"
 neon-serde = "0.0.3"
-fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "218d3aac6dc1559a2d42581921455a6d29b37542" }
+fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "3c85f2a9b5f49e4adf052799f09a5f6680efec7e" }

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,4 +17,4 @@ neon = "0.1.23"
 serde = "1.x"
 serde_derive = "1.x"
 neon-serde = "0.0.3"
-fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "c18ffaec48b285d441eb9f332d4681eb665ebb22" }
+fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "9da10eebec306b4dde8903b9d74ef9656f1c2f79" }

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,4 +17,4 @@ neon = "0.1.23"
 serde = "1.x"
 serde_derive = "1.x"
 neon-serde = "0.0.3"
-fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "c18ffaec48b285d441eb9f332d4681eb665ebb22" }
+fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "eb9a4822f4ed8d9a57311bf834199ff0be129777" }

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,4 +17,4 @@ neon = "0.1.23"
 serde = "1.x"
 serde_derive = "1.x"
 neon-serde = "0.0.3"
-fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "eb9a4822f4ed8d9a57311bf834199ff0be129777" }
+fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "218d3aac6dc1559a2d42581921455a6d29b37542" }

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,4 +17,4 @@ neon = "0.1.23"
 serde = "1.x"
 serde_derive = "1.x"
 neon-serde = "0.0.3"
-fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "0b03cbf1aede9d0a43aa28dffa828e2c62f1484e" }
+fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "c18ffaec48b285d441eb9f332d4681eb665ebb22" }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -9,7 +9,7 @@ use neon::js::{JsFunction, Object, JsString, JsNumber, Value, JsUndefined, JsArr
 use neon::js::class::{JsClass, Class};
 use neon::js::error::{Kind, JsError};
 
-use fuzzy_phrase::glue::{FuzzyPhraseSetBuilder, FuzzyPhraseSet};
+use fuzzy_phrase::glue::{FuzzyPhraseSetBuilder, FuzzyPhraseSet, WordReplacement};
 
 trait CheckArgument {
     fn check_argument<V: Value>(&mut self, i: i32) -> JsResult<V>;
@@ -68,6 +68,24 @@ declare_types! {
                     },
                     None => {
                         JsError::throw(Kind::TypeError, "unable to insert()")
+                    }
+                }
+            })
+        }
+
+        method loadWordReplacements(call) {
+            let scope = call.scope;
+            let mut this: Handle<JsFuzzyPhraseSetBuilder> = call.arguments.this(call.scope);
+            let mut v: Vec<WordReplacement> = Vec::new();
+
+            this.grab(|fuzzyphrasesetbuilder| {
+                match fuzzyphrasesetbuilder {
+                    Some(builder) => {
+                        match builder.load_word_replacements(v) {
+                        }
+                    },
+                    None => {
+                        JsError::throw(Kind::TypeError, "unable to load_word_replacements()")
                     }
                 }
             })

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -75,13 +75,21 @@ declare_types! {
 
         method loadWordReplacements(call) {
             let scope = call.scope;
-            let mut this: Handle<JsFuzzyPhraseSetBuilder> = call.arguments.this(call.scope);
-            let mut v: Vec<WordReplacement> = Vec::new();
+            let mut this: Handle<JsFuzzyPhraseSetBuilder> = call.arguments.this(scope);
+            let word_array = call.arguments.require(scope, 0)?;
+            let word_replacements: Vec<WordReplacement> = neon_serde::from_value(scope, word_array)?;
 
             this.grab(|fuzzyphrasesetbuilder| {
                 match fuzzyphrasesetbuilder {
                     Some(builder) => {
-                        match builder.load_word_replacements(v) {
+                        match builder.load_word_replacements(word_replacements) {
+                            Ok(_) => {
+                                Ok(JsUndefined::new().upcast())
+                            },
+                            Err(e) => {
+                                println!("{:?}", e);
+                                JsError::throw(Kind::TypeError, e.description())
+                            }
                         }
                     },
                     None => {

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -5,7 +5,7 @@ extern crate neon_serde;
 
 use neon::mem::Handle;
 use neon::vm::{This, Lock, FunctionCall, JsResult};
-use neon::js::{JsFunction, Object, JsString, Value, JsUndefined, JsArray, JsBoolean, JsInteger, JsObject};
+use neon::js::{JsFunction, Object, JsString, Value, JsUndefined, JsArray, JsBoolean, JsInteger};
 use neon::js::class::{JsClass, Class};
 use neon::js::error::{Kind, JsError};
 

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -82,15 +82,8 @@ declare_types! {
             this.grab(|fuzzyphrasesetbuilder| {
                 match fuzzyphrasesetbuilder {
                     Some(builder) => {
-                        match builder.load_word_replacements(word_replacements) {
-                            Ok(_) => {
-                                Ok(JsUndefined::new().upcast())
-                            },
-                            Err(e) => {
-                                println!("{:?}", e);
-                                JsError::throw(Kind::TypeError, e.description())
-                            }
-                        }
+                        builder.load_word_replacements(word_replacements);
+                        Ok(JsUndefined::new().upcast())
                     },
                     None => {
                         JsError::throw(Kind::TypeError, "unable to load_word_replacements()")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/node-fuzzy-phrase",
-  "version": "0.1.3",
+  "version": "0.1.3-tokens-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/node-fuzzy-phrase",
-  "version": "0.1.3-tokens-1",
+  "version": "0.1.3-wb-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/node-fuzzy-phrase",
-  "version": "0.1.3-tokens",
+  "version": "0.1.3-tokens-1",
   "description": "neon module for wrapping fuzzy-phrase",
   "main": "lib/index.js",
   "author": "Andrea del Rio <adelrio@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/node-fuzzy-phrase",
-  "version": "0.1.3-tokens-1",
+  "version": "0.1.3-wb-1",
   "description": "neon module for wrapping fuzzy-phrase",
   "main": "lib/index.js",
   "author": "Andrea del Rio <adelrio@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/node-fuzzy-phrase",
-  "version": "0.1.3",
+  "version": "0.1.3-tokens",
   "description": "neon module for wrapping fuzzy-phrase",
   "main": "lib/index.js",
   "author": "Andrea del Rio <adelrio@gmail.com>",

--- a/test/all.js
+++ b/test/all.js
@@ -36,116 +36,116 @@ tape('FuzzyPhraseSetBuilder insertion and Set lookup', (t) => {
     builder.finish();
 
     const set = new fuzzy.FuzzyPhraseSet(tmpDir.name);
-    t.ok(set.contains(['100', 'main', 'street']), 'FuzzyPhraseSet contains()');
-    t.ok(set.contains(['200', 'main', 'street']), 'FuzzyPhraseSet contains()');
-    t.ok(set.contains(['100', 'main', 'ave']), 'FuzzyPhraseSet contains()');
-    t.ok(set.contains(['300', 'mlk', 'blvd']), 'FuzzyPhraseSet contains()');
+    t.ok(set.contains(['100', 'main', 'street'], fuzzy.ENDING_TYPE.nonPrefix), 'FuzzyPhraseSet contains()');
+    t.ok(set.contains(['200', 'main', 'street'], fuzzy.ENDING_TYPE.nonPrefix), 'FuzzyPhraseSet contains()');
+    t.ok(set.contains(['100', 'main', 'ave'], fuzzy.ENDING_TYPE.nonPrefix), 'FuzzyPhraseSet contains()');
+    t.ok(set.contains(['300', 'mlk', 'blvd'], fuzzy.ENDING_TYPE.nonPrefix), 'FuzzyPhraseSet contains()');
 
-    t.ok(set.contains(['100', 'main', 'street']), 'FuzzyPhraseSet contains()');
+    t.ok(set.contains(['100', 'main', 'street'], fuzzy.ENDING_TYPE.nonPrefix), 'FuzzyPhraseSet contains()');
     const phraseStatic = ['100', 'main', 'street'];
-    t.ok(set.contains(phraseStatic), 'FuzzyPhraseSet contains()');
+    t.ok(set.contains(phraseStatic, fuzzy.ENDING_TYPE.nonPrefix), 'FuzzyPhraseSet contains()');
     const phraseVec = ['100', 'main', 'street'];
-    t.ok(set.contains(phraseVec), 'FuzzyPhraseSet contains()');
+    t.ok(set.contains(phraseVec, fuzzy.ENDING_TYPE.nonPrefix), 'FuzzyPhraseSet contains()');
 
-    t.notOk(set.contains(['x']), 'FuzzyPhraseSet does not contains()');
-    t.notOk(set.contains(['100', 'main']), 'FuzzyPhraseSet does not contains()');
+    t.notOk(set.contains(['x'], fuzzy.ENDING_TYPE.nonPrefix), 'FuzzyPhraseSet does not contains()');
+    t.notOk(set.contains(['100', 'main'], fuzzy.ENDING_TYPE.nonPrefix), 'FuzzyPhraseSet does not contains()');
     t.notOk(
-        set.contains(['100', 'main', 's']),
+        set.contains(['100', 'main', 's'], fuzzy.ENDING_TYPE.nonPrefix),
         'FuzzyPhraseSet does not contains()'
     );
     t.notOk(
-        set.contains(['100', 'main', 'streetr']),
+        set.contains(['100', 'main', 'streetr'], fuzzy.ENDING_TYPE.nonPrefix),
         'FuzzyPhraseSet does not contains()'
     );
     t.notOk(
-        set.contains(['100', 'main', 'street', 'r']),
+        set.contains(['100', 'main', 'street', 'r'], fuzzy.ENDING_TYPE.nonPrefix),
         'FuzzyPhraseSet does not contains()'
     );
     t.notOk(
-        set.contains(['100', 'main', 'street', 'ave']),
+        set.contains(['100', 'main', 'street', 'ave'], fuzzy.ENDING_TYPE.nonPrefix),
         'FuzzyPhraseSet does not contains()'
     );
 
     t.ok(
-        set.containsPrefix(['100', 'main', 'street']),
+        set.contains(['100', 'main', 'street'], fuzzy.ENDING_TYPE.anyPrefix),
         'FuzzyPhraseSet containsPrefix()'
     );
     t.ok(
-        set.containsPrefix(['200', 'main', 'street']),
+        set.contains(['200', 'main', 'street'], fuzzy.ENDING_TYPE.anyPrefix),
         'FuzzyPhraseSet containsPrefix()'
     );
     t.ok(
-        set.containsPrefix(['100', 'main', 'ave']),
+        set.contains(['100', 'main', 'ave'], fuzzy.ENDING_TYPE.anyPrefix),
         'FuzzyPhraseSet containsPrefix()'
     );
     t.ok(
-        set.containsPrefix(['300', 'mlk', 'blvd']),
+        set.contains(['300', 'mlk', 'blvd'], fuzzy.ENDING_TYPE.anyPrefix),
         'FuzzyPhraseSet containsPrefix()'
     );
 
-    t.ok(set.containsPrefix(['100', 'main']), 'FuzzyPhraseSet containsPrefix()');
-    t.ok(set.containsPrefix(['200', 'main']), 'FuzzyPhraseSet containsPrefix()');
-    t.ok(set.containsPrefix(['100', 'main']), 'FuzzyPhraseSet containsPrefix()');
-    t.ok(set.containsPrefix(['300', 'mlk']), 'FuzzyPhraseSet containsPrefix()');
+    t.ok(set.contains(['100', 'main'], fuzzy.ENDING_TYPE.anyPrefix), 'FuzzyPhraseSet containsPrefix()');
+    t.ok(set.contains(['200', 'main'], fuzzy.ENDING_TYPE.anyPrefix), 'FuzzyPhraseSet containsPrefix()');
+    t.ok(set.contains(['100', 'main'], fuzzy.ENDING_TYPE.anyPrefix), 'FuzzyPhraseSet containsPrefix()');
+    t.ok(set.contains(['300', 'mlk'], fuzzy.ENDING_TYPE.anyPrefix), 'FuzzyPhraseSet containsPrefix()');
 
     t.notOk(
-        set.containsPrefix(['100', 'man']),
+        set.contains(['100', 'man'], fuzzy.ENDING_TYPE.anyPrefix),
         'FuzzyPhraseSet does not containsPrefix()'
     );
     t.notOk(
-        set.containsPrefix(['400', 'main']),
+        set.contains(['400', 'main'], fuzzy.ENDING_TYPE.anyPrefix),
         'FuzzyPhraseSet does not containsPrefix()'
     );
     t.notOk(
-        set.containsPrefix(['100', 'main', 'street', 'x']),
+        set.contains(['100', 'main', 'street', 'x'], fuzzy.ENDING_TYPE.anyPrefix),
         'FuzzyPhraseSet does not containsPrefix()'
     );
 
     t.ok(
-        set.fuzzyMatch(['100', 'man', 'street'], 1, 1),
-        'FuzzyPhraseSet fuzzyMatch()'
+        set.fuzzyMatch(['100', 'man', 'street'], 1, 1, fuzzy.ENDING_TYPE.nonPrefix),
+        'FuzzyPhraseSet fuzzyMatch(..., fuzzy.ENDING_TYPE.nonPrefix)'
     );
 
     t.deepEquals(
-        set.fuzzyMatch(['100', 'man', 'street'], 1, 1),
-        [{ edit_distance: 1, phrase: ['100', 'main', 'street'] }],
-        'FuzzyPhraseSet fuzzyMatch()'
+        set.fuzzyMatch(['100', 'man', 'street'], 1, 1, fuzzy.ENDING_TYPE.nonPrefix),
+        [{ edit_distance: 1, phrase: ['100', 'main', 'street'], ending_type: fuzzy.ENDING_TYPE.nonPrefix }],
+        'FuzzyPhraseSet fuzzyMatch(..., fuzzy.ENDING_TYPE.nonPrefix)'
     );
 
     t.deepEquals(
-        set.fuzzyMatch(['100', 'man', 'stret'], 1, 2),
-        [{ edit_distance: 2, phrase: ['100', 'main', 'street'] }],
-        'FuzzyPhraseSet fuzzyMatch()'
+        set.fuzzyMatch(['100', 'man', 'stret'], 1, 2, fuzzy.ENDING_TYPE.nonPrefix),
+        [{ edit_distance: 2, phrase: ['100', 'main', 'street'], ending_type: fuzzy.ENDING_TYPE.nonPrefix }],
+        'FuzzyPhraseSet fuzzyMatch(..., fuzzy.ENDING_TYPE.nonPrefix)'
     );
 
     t.deepEquals(
-        set.fuzzyMatchPrefix(['100', 'man'], 1, 1),
-        [{ phrase: ['100', 'main'], edit_distance: 1 }],
-        'FuzzyPhraseSet fuzzyMatchPrefix()'
+        set.fuzzyMatch(['100', 'man'], 1, 1, fuzzy.ENDING_TYPE.anyPrefix),
+        [{ phrase: ['100', 'main'], edit_distance: 1, ending_type: fuzzy.ENDING_TYPE.wordBoundaryPrefix }],
+        'FuzzyPhraseSet fuzzyMatch(..., fuzzy.ENDING_TYPE.anyPrefix)'
     );
 
     t.deepEquals(
-        set.fuzzyMatchPrefix(['100', 'man', 'str'], 1, 1),
-        [{ phrase: ['100', 'main', 'str'], edit_distance: 1 }],
-        'FuzzyPhraseSet fuzzyMatchPrefix()'
+        set.fuzzyMatch(['100', 'man', 'str'], 1, 1, fuzzy.ENDING_TYPE.anyPrefix),
+        [{ phrase: ['100', 'main', 'str'], edit_distance: 1, ending_type: fuzzy.ENDING_TYPE.anyPrefix }],
+        'FuzzyPhraseSet fuzzyMatch(..., fuzzy.ENDING_TYPE.anyPrefix)'
     );
 
     t.deepEquals(
         set.fuzzyMatchMulti(
             [
-                [['100', 'man', 'street'], false],
-                [['100', 'man', 'stret'], false],
-                [['100', 'man'], true],
-                [['100', 'man', 'str'], true]
+                [['100', 'man', 'street'], fuzzy.ENDING_TYPE.nonPrefix],
+                [['100', 'man', 'stret'], fuzzy.ENDING_TYPE.nonPrefix],
+                [['100', 'man'], fuzzy.ENDING_TYPE.anyPrefix],
+                [['100', 'man', 'str'], fuzzy.ENDING_TYPE.anyPrefix]
             ],
             1,
             2
         ),
         [
-            [{ edit_distance: 1, phrase: ['100', 'main', 'street'] }],
-            [{ edit_distance: 2, phrase: ['100', 'main', 'street'] }],
-            [{ phrase: ['100', 'main'], edit_distance: 1 }],
-            [{ phrase: ['100', 'main', 'str'], edit_distance: 1 }]
+            [{ edit_distance: 1, phrase: ['100', 'main', 'street'], ending_type: fuzzy.ENDING_TYPE.nonPrefix }],
+            [{ edit_distance: 2, phrase: ['100', 'main', 'street'], ending_type: fuzzy.ENDING_TYPE.nonPrefix }],
+            [{ phrase: ['100', 'main'], edit_distance: 1, ending_type: fuzzy.ENDING_TYPE.wordBoundaryPrefix }],
+            [{ phrase: ['100', 'main', 'str'], edit_distance: 1, ending_type: fuzzy.ENDING_TYPE.anyPrefix }]
         ],
         'FuzzyPhraseSet fuzzyMatchMulti()'
     );
@@ -155,7 +155,7 @@ tape('FuzzyPhraseSetBuilder insertion and Set lookup', (t) => {
             '100 man street washington 200'.split(' '),
             0,
             0,
-            false
+            fuzzy.ENDING_TYPE.nonPrefix
         ),
         []
     );
@@ -165,12 +165,12 @@ tape('FuzzyPhraseSetBuilder insertion and Set lookup', (t) => {
             '100 man street washington 200'.split(' '),
             1,
             1,
-            false
+            fuzzy.ENDING_TYPE.nonPrefix
         ),
         [
             {
                 edit_distance: 1,
-                ends_in_prefix: false,
+                ending_type: fuzzy.ENDING_TYPE.nonPrefix,
                 phrase: ['100', 'main', 'street'],
                 start_position: 0
             }
@@ -182,18 +182,18 @@ tape('FuzzyPhraseSetBuilder insertion and Set lookup', (t) => {
             '100 man street washington 200'.split(' '),
             1,
             1,
-            true
+            fuzzy.ENDING_TYPE.anyPrefix
         ),
         [
             {
                 edit_distance: 1,
-                ends_in_prefix: false,
+                ending_type: fuzzy.ENDING_TYPE.nonPrefix,
                 phrase: ['100', 'main', 'street'],
                 start_position: 0
             },
             {
                 edit_distance: 0,
-                ends_in_prefix: true,
+                ending_type: fuzzy.ENDING_TYPE.wordBoundaryPrefix,
                 phrase: ['200'],
                 start_position: 4
             }

--- a/test/all.js
+++ b/test/all.js
@@ -206,10 +206,10 @@ tape('FuzzyPhraseSetBuilder insertion and Set lookup', (t) => {
 });
 
 tape('load word replacements', (t) => {
-    let builder = new fuzzy.FuzzyPhraseSetBuilder(tmpDir.name);
+    const builder = new fuzzy.FuzzyPhraseSetBuilder(tmpDir.name);
     builder.loadWordReplacements([{ from: 'Street', to: 'Str' }]);
     builder.finish();
-    var word_replacements_obj = JSON.parse(fs.readFileSync(tmpDir.name + '/metadata.json')).word_replacements;
-    t.deepEquals(word_replacements_obj, [ { from: 'Street', to: 'Str' } ], 'ok, loads word replacements')
+    const word_replacements_obj = JSON.parse(fs.readFileSync(tmpDir.name + '/metadata.json')).word_replacements;
+    t.deepEquals(word_replacements_obj, [{ from: 'Street', to: 'Str' }], 'ok, loads word replacements');
     t.end();
 });

--- a/test/all.js
+++ b/test/all.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 const tape = require('tape');
 const tmp = require('tmp');
 const rimraf = require('rimraf').sync;
+const fs = require('fs');
 
 const tmpDir = tmp.dirSync();
 
@@ -129,5 +130,8 @@ tape("FuzzyPhraseSetBuilder insertion and Set lookup", (t) => {
 tape('load word replacements', (t) => {
     let builder = new fuzzy.FuzzyPhraseSetBuilder(tmpDir.name);
     builder.loadWordReplacements([{ from: 'Street', to: 'Str' }]);
+    builder.finish();
+    var word_replacements_obj = JSON.parse(fs.readFileSync(tmpDir.name + '/metadata.json')).word_replacements;
+    t.deepEquals(word_replacements_obj, [ { from: 'Street', to: 'Str' } ], 'ok, loads word replacements')
     t.end();
 })

--- a/test/all.js
+++ b/test/all.js
@@ -18,7 +18,6 @@ tape('build FuzzyPhraseSetBuilder', (t) => {
 
 tape("FuzzyPhraseSetBuilder insertion and Set lookup", (t) => {
     let builder = new fuzzy.FuzzyPhraseSetBuilder(tmpDir.name);
-
     builder.insert(["100","main","street"]);
     builder.insert(["200","main","street"]);
     builder.insert(["100","main","ave"]);
@@ -124,5 +123,11 @@ tape("FuzzyPhraseSetBuilder insertion and Set lookup", (t) => {
 
     rimraf(tmpDir.name);
 
+    t.end();
+})
+
+tape('load word replacements', (t) => {
+    let builder = new fuzzy.FuzzyPhraseSetBuilder(tmpDir.name);
+    builder.loadWordReplacements([{ from: 'Street', to: 'Str' }]);
     t.end();
 })


### PR DESCRIPTION
This PR updates to fuzzy-phrase@word-boundaries (see mapbox/fuzzy-phrase#66), and makes some corresponding changes:
- [x] mirror removal of *_prefix functions
- [x] mirror encoding of EndingType as an enum (encoded here as a number)
- [x] update tests

To do:
- [x] add tests specific to token replacement
- [x] add tests specific to word boundary behavior

fixes #15 