### PR TITLE
Switch to fuzzy-phrase@variable-bins, and wrap bin logic

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
 [[package]]
 name = "fuzzy-phrase"
 version = "0.1.0"
-source = "git+https://github.com/mapbox/fuzzy-phrase?rev=baed684386ffbefa5e115ce1f0150a884aaa0175#baed684386ffbefa5e115ce1f0150a884aaa0175"
+source = "git+https://github.com/mapbox/fuzzy-phrase?rev=daf61f773c3ecb98b77cf8f4e3d0983fa4159f83#daf61f773c3ecb98b77cf8f4e3d0983fa4159f83"
 dependencies = [
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fst 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -185,7 +185,7 @@ dependencies = [
 name = "node-fuzzy-phrase"
 version = "0.1.0"
 dependencies = [
- "fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=baed684386ffbefa5e115ce1f0150a884aaa0175)",
+ "fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=daf61f773c3ecb98b77cf8f4e3d0983fa4159f83)",
  "neon 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-serde 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -411,7 +411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum fst 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "db72126ca7dff566cdbbdd54af44668c544897d9d3862b198141f176f1238bdf"
-"checksum fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=baed684386ffbefa5e115ce1f0150a884aaa0175)" = "<none>"
+"checksum fuzzy-phrase 0.1.0 (git+https://github.com/mapbox/fuzzy-phrase?rev=daf61f773c3ecb98b77cf8f4e3d0983fa4159f83)" = "<none>"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,4 +17,4 @@ neon = "0.1.23"
 serde = "1.x"
 serde_derive = "1.x"
 neon-serde = "0.0.3"
-fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "baed684386ffbefa5e115ce1f0150a884aaa0175" }
+fuzzy-phrase = { git = "https://github.com/mapbox/fuzzy-phrase", rev = "daf61f773c3ecb98b77cf8f4e3d0983fa4159f83" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/node-fuzzy-phrase",
-  "version": "0.2.0-phrase-id-3",
+  "version": "0.2.0-variable-bins-1",
   "description": "neon module for wrapping fuzzy-phrase",
   "main": "lib/index.js",
   "author": "Andrea del Rio <adelrio@gmail.com>",

--- a/test/all.js
+++ b/test/all.js
@@ -359,6 +359,11 @@ tape('word replacements', (t) => {
     }
     t.deepEquals(regularResults, set.fuzzyMatchMulti(multiToTry, 1, 1));
 
+    // test bin boundary retrieval -- this index contains four phrases,
+    // two of which start with "100 main" and two with "100 f"
+    const bins = new Uint32Array(set.getPrefixBins(2));
+    t.deepEquals(bins, new Uint32Array([0, 2, 4]), "bins are as expected");
+
     rimraf(tmpDir.name);
 
     t.end();


### PR DESCRIPTION
This PR corresponds to mapbox/fuzzy-phrase#72 -- it wraps new functionality introduced in that PR to extract information from a fuzzy-phrase data structure about shared prefixes, to more efficiently pre-cache geometries in carmen-core for autocomplete queries. Since this data is effectively opaque to Carmen (we're going to pull it out of fuzzy-phrase and push it into carmen-core), we expose it as a single contiguous Javascript buffer of integers; these integers represent just the start position of each bin, plus a sentinel at the end representing the total number of phrases in the store. This means a buffer of IDs `[A, B, C, D]` can be effectively interpreted as a set of ranges `{ [A, B), [B, C), [C, D) }`.